### PR TITLE
LPS-29713 Google Maps Plugin: cannot edit the origin field even after it is configured to do so

### DIFF
--- a/portlets/google-maps-portlet/docroot/js/main.js
+++ b/portlets/google-maps-portlet/docroot/js/main.js
@@ -231,10 +231,14 @@ AUI.add(
 					_getMapAddress: function(value) {
 						var instance = this;
 
-						if (!Lang.isValue(value) && instance.get('mapInputEnabled')) {
+						if (instance.get('mapInputEnabled')) {
 							var mapAddressNode = instance.byId(STR_MAP_ADDRESS);
 
-							value = mapAddressNode.val();
+							var mapAddress = mapAddressNode.val();
+							
+							if (mapAddress) {
+								value = mapAddress;
+							}
 						}
 
 						return value;


### PR DESCRIPTION
Hi Iliyan,

The current behaviour of the map address text box when it can be edited is really weird because although you modify it, the map always loads the address set in the configuration panel. This occurs because if we don't fill the map address in the configuration, the portlet says "Please configure this portlet to make it visible to all users" so we always have to fill it and then the condition about I asked you yesterday avoid to load a new value entered by a user. This commit removes that condition and it loads the new address whenever it's not blank.

I have included the test done in the issue:
http://issues.liferay.com/browse/LPS-29713

Thanks.
